### PR TITLE
Kubernetes networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # emergy_platform
 emergy Platform repository
+
+kubernetes-networks
+- побавил проверки в kubernetes-intro\web-pod.yaml
+
+Почему следующая конфигурация валидна, но не имеет смысла?
+```
+livenessProbe:
+  exec:
+    command:
+      - 'sh'
+      - '-c'
+      - 'ps aux | grep my_web_server_process'
+```
+Потому что, если у нас запущен процесс веб сервера, это ещё не значет, что он запущен на необходимом порту и отдаёт то, что должен. Такая проверка имеет смысл, если у нас нет возможности запросить у приложения его статус.
+
+- создал kubernetes-networks\web-deploy.yaml, сделал template на основе kubernetes-intro\web-pod.yaml
+- удалил pod созданый до этого
+- исправил readinessProbe, увеличил количество реплик, примерил посмотрел, поигрался с strategy
+- создал kubernetes-networks\web-svc-cip.yaml, посмотрел правила iptables
+- включил IPVS, посморел листинг VIP'ов, интерфейс kube-ipvs0, таблицы ipset
+- создал kubernetes-networks\metallb-config.yaml и применил
+- создал kubernetes-networks\web-svc-lb.yaml и применил
+- добавил маршрут (ОС Windows) `route add 172.17.255.0 mask 255.255.255.0 192.168.99.102` - страничка открылась
+- с заданием DNS через MetalLB - ничего не вышло
+- установил ingress-nginx
+- создал kubernetes-networks\nginx-lb.yaml, постучался по адресу 172.17.255.2
+- создал kubernetes-networks\web-svc-headless.yaml, применил, убедился, что IP не назначен
+- создал kubernetes-networks\web-ingress.yaml, и применил
+```
+k describe ingress/web
+```
+вижу адрес виртуалки minikube и ошибку (<error: endpoints "default-http-backend" not found>
+```
+Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
+Name:             web
+Namespace:        default
+Address:          192.168.99.102
+Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
+Rules:
+  Host        Path  Backends
+  ----        ----  --------
+  *
+              /web   web-svc:8000   172.17.0.5:8000,172.17.0.7:8000,172.17.0.8:8000)
+Annotations:  nginx.ingress.kubernetes.io/rewrite-target: /
+Events:
+  Type    Reason  Age   From                      Message
+  ----    ------  ----  ----                      -------
+  Normal  CREATE  34s   nginx-ingress-controller  Ingress default/web
+  Normal  UPDATE  24s   nginx-ingress-controller  Ingress default/web
+  ```
+  тем не менее, адрес http://172.17.255.2/web/index.html - открылся в браузере

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -8,6 +8,12 @@ spec:
   containers:
     - name: kubernetes-intro
       image: emergy/kubernetes-intro
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 8000
+      livenessProbe:
+        tcpSocket: { port: 8000 }
       volumeMounts:
         - name: app
           mountPath: /app

--- a/kubernetes-networks/coredns/web-svc-lb-coredns.yaml
+++ b/kubernetes-networks/coredns/web-svc-lb-coredns.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb-coredns-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns-pub
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.2
+  ports:
+  - port: 53
+    protocol: TCP
+    targetPort: 53
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb-coredns-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns-pub
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.2
+  ports:
+  - port: 53
+    protocol: UDP
+    targetPort: 53

--- a/kubernetes-networks/coredns/web-svc-lb-coredns.yaml
+++ b/kubernetes-networks/coredns/web-svc-lb-coredns.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     k8s-app: kube-dns
   type: LoadBalancer
-  loadBalancerIP: 172.17.255.2
+  loadBalancerIP: 172.17.255.1
   ports:
   - port: 53
     protocol: TCP
@@ -28,7 +28,7 @@ spec:
   selector:
     k8s-app: kube-dns
   type: LoadBalancer
-  loadBalancerIP: 172.17.255.2
+  loadBalancerIP: 172.17.255.1
   ports:
   - port: 53
     protocol: UDP

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: kubernetes-intro
+          image: emergy/kubernetes-intro
+          volumeMounts:
+            - name: app
+              mountPath: /app
+          readinessProbe:
+            httpGet:
+              path: index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket: { port: 8000 }
+      initContainers:
+        - name: init-web
+          image: busybox:1.31.0
+          command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}
+

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -10,7 +10,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 100%
+      maxUnavailable: 0
       maxSurge: 100%
   template:
     metadata:
@@ -21,15 +21,15 @@ spec:
       containers:
         - name: kubernetes-intro
           image: emergy/kubernetes-intro
-          volumeMounts:
-            - name: app
-              mountPath: /app
           readinessProbe:
             httpGet:
-              path: index.html
+              path: /index.html
               port: 8000
           livenessProbe:
             tcpSocket: { port: 8000 }
+          volumeMounts:
+            - name: app
+              mountPath: /app
       initContainers:
         - name: init-web
           image: busybox:1.31.0
@@ -40,4 +40,3 @@ spec:
       volumes:
         - name: app
           emptyDir: {}
-

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -7,6 +7,6 @@ spec:
     app: web
   type: ClusterIP
   ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 8000
+    - port: 80
+      protocol: TCP
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
- побавил проверки в kubernetes-intro\web-pod.yaml

Почему следующая конфигурация валидна, но не имеет смысла?
```
livenessProbe:
  exec:
    command:
      - 'sh'
      - '-c'
      - 'ps aux | grep my_web_server_process'
```
Потому что, если у нас запущен процесс веб сервера, это ещё не значет, что он запущен на необходимом порту и отдаёт то, что должен. Такая проверка имеет смысл, если у нас нет возможности запросить у приложения его статус.

- создал kubernetes-networks\web-deploy.yaml, сделал template на основе kubernetes-intro\web-pod.yaml
- удалил pod созданый до этого
- исправил readinessProbe, увеличил количество реплик, примерил посмотрел, поигрался с strategy
- создал kubernetes-networks\web-svc-cip.yaml, посмотрел правила iptables
- включил IPVS, посморел листинг VIP'ов, интерфейс kube-ipvs0, таблицы ipset
- создал kubernetes-networks\metallb-config.yaml и применил
- создал kubernetes-networks\web-svc-lb.yaml и применил
- добавил маршрут (ОС Windows) `route add 172.17.255.0 mask 255.255.255.0 192.168.99.102` - страничка открылась
- с заданием DNS через MetalLB - ничего не вышло
- установил ingress-nginx
- создал kubernetes-networks\nginx-lb.yaml, постучался по адресу 172.17.255.2
- создал kubernetes-networks\web-svc-headless.yaml, применил, убедился, что IP не назначен
- создал kubernetes-networks\web-ingress.yaml, и применил
```
k describe ingress/web
```
вижу адрес виртуалки minikube и ошибку (<error: endpoints "default-http-backend" not found>
```
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
Name:             web
Namespace:        default
Address:          192.168.99.102
Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
Rules:
  Host        Path  Backends
  ----        ----  --------
  *
              /web   web-svc:8000   172.17.0.5:8000,172.17.0.7:8000,172.17.0.8:8000)
Annotations:  nginx.ingress.kubernetes.io/rewrite-target: /
Events:
  Type    Reason  Age   From                      Message
  ----    ------  ----  ----                      -------
  Normal  CREATE  34s   nginx-ingress-controller  Ingress default/web
  Normal  UPDATE  24s   nginx-ingress-controller  Ingress default/web
  ```
  тем не менее, адрес http://172.17.255.2/web/index.html - открылся в браузере

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
